### PR TITLE
Compatibility w/ 3.6.0

### DIFF
--- a/Auth.php
+++ b/Auth.php
@@ -50,7 +50,7 @@ class Auth extends \Piwik\Plugins\Login\Auth
      * Returns if the current session is validated with auth code
      * @return bool
      */
-    public function getValidatedWithAuthCode()
+    protected function getValidatedWithAuthCode()
     {
         if (!is_null($this->validatedWithAuthCode)) {
             return $this->validatedWithAuthCode;

--- a/Controller.php
+++ b/Controller.php
@@ -81,8 +81,7 @@ class Controller extends \Piwik\Plugins\Login\Controller
         if ($form->getSubmitValue('form_authcode') && $form->validate()) {
             $nonce = $form->getSubmitValue('form_nonce');
             if (Nonce::verifyNonce('Login.login', $nonce)) {
-                $sac = $form->getSubmitValue('form_authcode');
-                $this->auth->setAuthCode($sac);
+                $this->auth->setAuthCode($form->getSubmitValue('form_authcode'));
                 if ($this->auth->validateAuthCode()) {
                     try {
                         $rememberMe = Common::getRequestVar('form_rememberme', '0', 'string') == '1';

--- a/Controller.php
+++ b/Controller.php
@@ -81,7 +81,8 @@ class Controller extends \Piwik\Plugins\Login\Controller
         if ($form->getSubmitValue('form_authcode') && $form->validate()) {
             $nonce = $form->getSubmitValue('form_nonce');
             if (Nonce::verifyNonce('Login.login', $nonce)) {
-                $this->auth->setAuthCode($form->getSubmitValue('form_authcode'));
+                $sac = $form->getSubmitValue('form_authcode');
+                $this->auth->setAuthCode($sac);
                 if ($this->auth->validateAuthCode()) {
                     try {
                         $rememberMe = Common::getRequestVar('form_rememberme', '0', 'string') == '1';
@@ -126,7 +127,6 @@ class Controller extends \Piwik\Plugins\Login\Controller
 
         return $view->render();
     }
-
 
     /**
      * Pretty the same as in login action of Login plugin
@@ -398,5 +398,14 @@ class Controller extends \Piwik\Plugins\Login\Controller
     protected function getCurrentQRUrl()
     {
         return sprintf('index.php?module=GoogleAuthenticator&action=showQrCode&cb=%s&current=1', Common::getRandomString(8));
+    }
+
+    private function redirectToAuthCode()
+    {
+        $urlToRedirect = Url::getCurrentUrlWithoutQueryString() . Url::getCurrentQueryStringWithParametersModified([
+            'module' => 'GoogleAuthenticator',
+            'action' => 'authcode',
+        ]);
+        Url::redirectToUrl($urlToRedirect);
     }
 }

--- a/Controller.php
+++ b/Controller.php
@@ -399,13 +399,4 @@ class Controller extends \Piwik\Plugins\Login\Controller
     {
         return sprintf('index.php?module=GoogleAuthenticator&action=showQrCode&cb=%s&current=1', Common::getRandomString(8));
     }
-
-    private function redirectToAuthCode()
-    {
-        $urlToRedirect = Url::getCurrentUrlWithoutQueryString() . Url::getCurrentQueryStringWithParametersModified([
-            'module' => 'GoogleAuthenticator',
-            'action' => 'authcode',
-        ]);
-        Url::redirectToUrl($urlToRedirect);
-    }
 }

--- a/GoogleAuthenticator.php
+++ b/GoogleAuthenticator.php
@@ -9,9 +9,7 @@
 namespace Piwik\Plugins\GoogleAuthenticator;
 
 use Piwik\Common;
-use Piwik\Config;
 use Piwik\Container\StaticContainer;
-use Piwik\Cookie;
 use Piwik\FrontController;
 use Piwik\Notification;
 use Piwik\Piwik;
@@ -67,36 +65,7 @@ class GoogleAuthenticator extends \Piwik\Plugins\Login\Login
      */
     public static function initAuthenticationFromCookie(\Piwik\Auth $auth, $activateCookieAuth)
     {
-        if (self::isModuleIsAPI() && !$activateCookieAuth) {
-            return;
-        }
-
-        $authCookieName = Config::getInstance()->General['login_cookie_name'];
-        $authCookieExpiry = 0;
-        $authCookiePath = Config::getInstance()->General['login_cookie_path'];
-        $authCookie = new Cookie($authCookieName, $authCookieExpiry, $authCookiePath);
-        $defaultLogin = 'anonymous';
-        $defaultTokenAuth = 'anonymous';
-        if ($authCookie->isCookieFound()) {
-            $defaultLogin = $authCookie->get('login');
-            $defaultTokenAuth = $authCookie->get('token_auth');
-        }
-        $auth->setLogin($defaultLogin);
-        $auth->setTokenAuth($defaultTokenAuth);
-
-        $storage = new Storage($defaultLogin);
-
-        if (!$storage->isActive()) {
-            return;
-        }
-
-        $secret = $storage->getSecret();
-        $cookieSecret = $authCookie->get('auth_code');
-        if ($cookieSecret == SessionInitializer::getHashTokenAuth($defaultLogin, $secret)) {
-            $googleAuth = StaticContainer::get('GoogleAuthenticator');
-            $auth->setAuthCode($googleAuth->getCode($secret));
-            $auth->validateAuthCode();
-        }
+        // empty
     }
 
     /**

--- a/SessionAuth.php
+++ b/SessionAuth.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ *
+ */
+
+namespace Piwik\Plugins\GoogleAuthenticator;
+
+use Piwik\AuthResult;
+use Piwik\Session\SessionFingerprint;
+use Piwik\Session\SessionNamespace;
+
+class SessionAuth extends \Piwik\Session\SessionAuth
+{
+    public function authenticate()
+    {
+        $sessionFingerprint = new SessionFingerprint();
+        if ($sessionFingerprint->getUser()) {
+            $storage = new Storage($sessionFingerprint->getUser());
+            if (!$storage->isActive()) {
+                return parent::authenticate();
+            }
+
+            $session = new SessionNamespace('GoogleAuthenticator');
+            if (!$session->validatedWithAuthCode) {
+                return new AuthResult(Auth::AUTH_CODE_REQUIRED, $sessionFingerprint->getUser(), null);
+            }
+        }
+
+        return parent::authenticate();
+    }
+}

--- a/SessionInitializer.php
+++ b/SessionInitializer.php
@@ -66,22 +66,5 @@ class SessionInitializer extends \Piwik\Session\SessionInitializer
         if ($storage->isActive() && $authResult->wasAuthenticationSuccessful()) {
             $_SESSION['auth_code'] = $this->getHashTokenAuth($authResult->getIdentity(), $storage->getSecret());
         }
-
-        $this->setValidatedWithAuthCode(true);
-    }
-
-    /**
-     * Sets whether the current session is validated with auth code
-     * @param bool|true $isValid
-     */
-    protected function setValidatedWithAuthCode($isValid = true)
-    {
-        $this->validatedWithAuthCode = $isValid;
-        try {
-            $session = new SessionNamespace('GoogleAuthenticator');
-            $session->validatedWithAuthCode = $isValid;
-        } catch (Exception $e) {
-            // ignore as that should only happen in tests
-        }
     }
 }

--- a/config/config.php
+++ b/config/config.php
@@ -1,10 +1,13 @@
 <?php
 
+use Piwik\Plugins\GoogleAuthenticator\SessionAuth;
+
 require dirname(dirname(__FILE__)) . '/vendor/autoload.php';
 
 return array(
     'Piwik\Auth' => DI\object('Piwik\Plugins\GoogleAuthenticator\Auth'),
     'GoogleAuthenticator' => DI\factory(function() {
         return new Piwik\Plugins\GoogleAuthenticator\PHPGangsta\GoogleAuthenticator();
-    })
+    }),
+    \Piwik\Session\SessionAuth::class => DI\object(SessionAuth::class),
 );

--- a/plugin.json
+++ b/plugin.json
@@ -7,7 +7,7 @@
   "license": "BSD AND GPL-3.0+",
   "homepage": "https://github.com/sgiehl/piwik-plugin-GoogleAuthenticator",
   "require": {
-    "piwik": ">=3.0.0-b1,<3.6.0-b1",
+    "piwik": ">=3.0.0-b1",
     "php": ">=5.5"
   },
   "authors": [


### PR DESCRIPTION
Changes:
- Use SessionAuth in GoogleAuthenticator Auth implementation if user logs in via Login plugin.
- Set GoogleAuthenticator session in SessionInitializer after session is initialized.
- Put auth_code in _SESSION (not sure if needed).